### PR TITLE
Implement a generic groupBy function

### DIFF
--- a/src/group-by/group-by.js
+++ b/src/group-by/group-by.js
@@ -1,0 +1,45 @@
+const partition = require("../partition/partition")
+
+const groupByFn = f => input => {
+  if (input.length === 0) {
+    return input
+  }
+
+  const [head, ...tail] = input
+
+  const [sameGroup, otherGroup] = partition(f(head))(tail)
+
+  return [[head, ...sameGroup], ...groupByFn(f)(otherGroup)]
+}
+
+const groupByKey = key => {
+  return groupByFn(x => y => x[key] === y[key])
+}
+
+/**
+ * groupBy groups values from a list into a list of lists.
+ *
+ * @param   {Function|Object} grouper   A *curried* function which takes two
+ *                                      values, returning a boolean (true if
+ *                                      they should be grouped, false
+ *                                      otherwise.) The default behavior.
+ *                                      See `groupByFn`.
+ *
+ *                                      If the input is a string, groups
+ *                                      a list of objects by the value of the
+ *                                      corresponding key. See `groupByKey`.
+ * @param   {[]}              implicit  List of values to be grouped
+ *
+ * @return {[[]]}                       List of lists of values in the same
+ *                                      group
+ *
+ * @example
+ * groupBy(x => y => x % 2 === y % 2)([1,2,3,4,5]) = [[1,3,5], [2,4]]
+ */
+module.exports = grouper => {
+  if (typeof grouper === "string") {
+    return groupByKey(grouper)
+  }
+
+  return groupByFn(grouper)
+}

--- a/src/group-by/group-by.js
+++ b/src/group-by/group-by.js
@@ -7,9 +7,9 @@ const groupByFn = f => input => {
 
   const [head, ...tail] = input
 
-  const [sameGroup, otherGroup] = partition(f(head))(tail)
+  const [sameGroup, otherGroups] = partition(f(head))(tail)
 
-  return [[head, ...sameGroup], ...groupByFn(f)(otherGroup)]
+  return [[head, ...sameGroup], ...groupByFn(f)(otherGroups)]
 }
 
 const groupByKey = key => {

--- a/src/group-by/group-by.test.js
+++ b/src/group-by/group-by.test.js
@@ -1,0 +1,34 @@
+const test = require("tape")
+const groupBy = require("./group-by")
+
+test("array::groupBy", t => {
+  const sameParity = x => y => x % 2 === y % 2
+  const key = "test"
+
+  t.deepEqual(
+    groupBy(sameParity)([1, 2, 3, 4, 5]),
+    [[1, 3, 5], [2, 4]],
+    "(sameParity)([1,2,3,4,5]) // => [[1,3,5], [2,4]]"
+  )
+
+  t.deepEqual(
+    groupBy(key)([
+      {
+        test: "a",
+      },
+      {
+        test: "b",
+      },
+      {
+        test: "c",
+      },
+      {
+        test: "b",
+      },
+    ]),
+    [[{ test: "a" }], [{ test: "b" }, { test: "b" }], [{ test: "c" }]],
+    "objects with the same value at the given key should be grouped"
+  )
+
+  t.end()
+})

--- a/src/partition/partition.js
+++ b/src/partition/partition.js
@@ -1,0 +1,23 @@
+/**
+ * partition splits a list based on a predicate function.
+ *
+ * @param   {Function}  p       The predicate function, which returns a
+ *                              truthy or falsy value for every value given
+ *                              an input
+ *
+ * @param   {[]}        input   List of values to test
+ */
+module.exports = p => input => {
+  const pass = []
+  const fail = []
+
+  for (let i = 0; i < input.length; i++) {
+    if (p(input[i])) {
+      pass.push(input[i])
+    } else {
+      fail.push(input[i])
+    }
+  }
+
+  return [pass, fail]
+}

--- a/src/partition/partition.test.js
+++ b/src/partition/partition.test.js
@@ -1,0 +1,20 @@
+const test = require("tape")
+const partition = require("./partition")
+
+test("array::partition", t => {
+  const equalsTwo = x => x === 2
+
+  t.deepEqual(
+    partition(equalsTwo)([2, 2, 1, 1, 2]),
+    [[2, 2, 2], [1, 1]],
+    "(equalsTwo)([2,2,1,1,2]) // => [[2,2,2],[1,1]]"
+  )
+
+  t.deepEqual(
+    partition(equalsTwo)([1]),
+    [[], [1]],
+    "(equalsTwo)([1]) // => [[], [1]]"
+  )
+
+  t.end()
+})


### PR DESCRIPTION
The `indexBy` in the library only works on arrays of objects, this PR introduces a more generic function `groupBy` for grouping which can be used on any type of array. It also returns its output as a list of lists rather than an object, making it amenable to list processing over the results.

Additionally introduces `partition` as a helper function, which could be useful as a building block for other functions (e.g. `filter` could be thought of a special case of `partition`.)