### PR TITLE
Add function: curry

### DIFF
--- a/lib/docs-theme/assets/style.css
+++ b/lib/docs-theme/assets/style.css
@@ -85,6 +85,7 @@ h4:hover .anchorjs-link {
 .pre, pre, code, .code {
   font-family: Source Code Pro,Menlo,Consolas,Liberation Mono,monospace;
   font-size: 14px;
+  white-space: pre;
 }
 
 .fill-light {

--- a/src/curry/curry.js
+++ b/src/curry/curry.js
@@ -8,7 +8,9 @@ import type { CurryType } from "./curry.js.flow"
  * Partially apply a function.
  *
  * @signature
- * <A>(fn: Function) => (args: mixed[]) => A
+ * <A>(fn: (...args: mixed[]) => A) => CurryReturnType<A>
+ *
+ * where CurryReturnType<A> = (...mixed[]) => A | CurryReturnType<A>
  *
  * @param fn
  * The function to apply.
@@ -19,7 +21,8 @@ import type { CurryType } from "./curry.js.flow"
  * @return
  * If the number of arguments provided is sufficient to call the function,
  * call the function and return the result. Otherwise, return a new function
- * which takes additional parameters, returning the result of calling `curry` on the function with the original parameters and the additional parameters.
+ * which takes additional parameters, returning the result of calling `curry`
+ * on the function with the provided parameters.
  *
  * @example
  * curry((a, b) => a + b)(1)(2) = 3

--- a/src/curry/curry.js
+++ b/src/curry/curry.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-unused-vars*/
+
+// @flow
+
+import type { CurryType } from "./curry.js.flow"
+
+/**
+ * Partially apply a function.
+ *
+ * @signature
+ * <A>(fn: Function) => (args: mixed[]) => A
+ *
+ * @param fn
+ * The function to apply.
+ *
+ * @param args
+ * The arguments to apply, in order.
+ *
+ * @return
+ * If the number of arguments provided is sufficient to call the function,
+ * call the function and return the result. Otherwise, return a new function
+ * which takes additional parameters, returning the result of calling `curry` on the function with the original parameters and the additional parameters.
+ *
+ * @example
+ * curry((a, b) => a + b)(1)(2) = 3
+ */
+const curry: CurryType = <A>(fn) => (...args) =>
+  args.length >= fn.length
+    ? fn(...args)
+    : (...rest) => curry(fn)(...args, ...rest)
+
+export { curry }

--- a/src/curry/curry.js.flow
+++ b/src/curry/curry.js.flow
@@ -1,8 +1,8 @@
 // @flow
 
-type CurryType = <A>(
-  fn: (...args: Array<mixed>) => A
-) => (args: mixed[]) => A | ((rest: mixed[]) => A | ((mixed[]) => A))
+type CurryReturnType<A> = (...mixed[]) => A | CurryReturnType<A>
+
+type CurryType = <A>(fn: (...args: mixed[]) => A) => CurryReturnType<A>
 
 declare export var curry: CurryType
 

--- a/src/curry/curry.js.flow
+++ b/src/curry/curry.js.flow
@@ -1,0 +1,9 @@
+// @flow
+
+type CurryType = <A>(
+  fn: (...args: Array<mixed>) => A
+) => (args: mixed[]) => A | ((rest: mixed[]) => A | ((mixed[]) => A))
+
+declare export var curry: CurryType
+
+export type { CurryType }

--- a/src/curry/curry.test.js
+++ b/src/curry/curry.test.js
@@ -1,0 +1,27 @@
+import test from "tape"
+
+import { curry } from "./curry"
+
+test("fn::curry", t => {
+  const sum = (a, b) => a + b
+
+  // does nothing if there are enough parameters
+  t.equal(curry(sum)(2, 3), 5)
+
+  // curries the function if there aren't
+  const addTwo = curry(sum)(2)
+
+  t.equal(addTwo(3), 5)
+
+  // can curry multiple times and pass multiple parameters on each curry
+  const sumThree = (a, b, c) => a + b + c
+
+  const addOne = curry(sumThree)(1)
+  const addFourA = curry(addOne)(3)
+  const addFourB = curry(sumThree)(2, 2)
+
+  t.equal(addFourA(1), 5)
+  t.equal(addFourA(1), addFourB(1))
+
+  t.end()
+})

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ module.exports = {
   contains: require("./contains/contains"),
   count: require("./count/count"),
   countBy: require("./count-by/count-by"),
+  curry: require("./curry/curry").curry,
   debounce: require("./debounce/debounce"),
   deepEqual: require("./deep-equal/deep-equal"),
   distinct: require("./distinct/distinct"),

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -2,9 +2,11 @@
 /* eslint-disable flowtype/no-weak-types */
 // @flow
 
+import type { CurryType } from "./curry/curry.js.flow"
 import type { GroupByType } from "./group-by/group-by.js.flow"
 import type { PartitionType } from "./partition/partition.js.flow"
 
+declare export var curry: CurryType
 declare export var groupBy: GroupByType
 declare export var partition: PartitionType
 


### PR DESCRIPTION
Add a function `curry` that curries its input, allowing partial application over functions which were not written in the curried style.