### PR TITLE
Add a function for handling multiple conditionals

### DIFF
--- a/src/cases/cases.js
+++ b/src/cases/cases.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-unused-vars */
+// @flow
+
+import { ifThen } from "../if-then/if-then"
+import { i } from "../i/i"
+import type { CasesType } from "./cases.js.flow"
+
+/**
+ * Functional case statement.
+ *
+ * @signature
+ * <A, B>(
+ *   conditions: [(A) => boolean, (A) => B][],
+ *   otherwise: (A) => B
+ * ) => A => B
+ *
+ * @param conditions
+ * List of 2-tuples of functions (if, then)
+ * @param otherwise
+ * Function to call if no condition matches. Defaults to identity.
+ * @param input
+ * Value to check
+ *
+ * @returns
+ * The result of calling the first matching then function or the
+ * otherwise function on the input.
+ *
+ * @example
+ * case([
+ *  [x === 0, x => x * 2],
+ *  [x === 1, x => x],
+ * ], x => x + 1)(2) = 3
+ */
+const cases: CasesType = <A, B>(
+  [[conditionFn, thenFn], ...rest],
+  otherwise = i
+) => input =>
+  ifThen(
+    conditionFn,
+    thenFn,
+    rest.length !== 0 ? cases(rest, otherwise) : otherwise
+  )(input)
+
+export { cases }

--- a/src/cases/cases.js
+++ b/src/cases/cases.js
@@ -26,7 +26,7 @@ import type { CasesType } from "./cases.js.flow"
  * otherwise function on the input.
  *
  * @example
- * case([
+ * cases([
  *  [x === 0, x => x * 2],
  *  [x === 1, x => x],
  * ], x => x + 1)(2) = 3

--- a/src/cases/cases.js.flow
+++ b/src/cases/cases.js.flow
@@ -1,0 +1,10 @@
+// @flow
+
+type CasesType = <A, B>(
+  conditions: [(A) => boolean, (A) => B][],
+  otherwise: (A) => B
+) => A => B
+
+declare export var cases: CasesType
+
+export type { CasesType }

--- a/src/cases/cases.test.js
+++ b/src/cases/cases.test.js
@@ -1,0 +1,33 @@
+// @flow
+
+import test from "tape"
+import { cases } from ".."
+
+test("core::cases", t => {
+  t.equal(
+    cases([
+      [x => x % 2 === 0, x => x * 2],
+      [x => x % 2 === 1, x => x + 5],
+      [x => x === 2, x => x / 2],
+    ])(2),
+    4,
+    "cases should evaluate the first matching function over the input"
+  )
+
+  t.equal(
+    cases([[x => x % 2 === 0, x => x * 2], [x => x === 2, x => x / 2]])(3),
+    3,
+    "cases should return the original value otherwise"
+  )
+
+  t.equal(
+    cases(
+      [[x => x % 2 === 0, x => x * 2], [x => x === 2, x => x / 2]],
+      x => x * 3
+    )(3),
+    9,
+    "cases allows passing an alternative otherwise handler"
+  )
+
+  t.end()
+})

--- a/src/if-then/if-then.js
+++ b/src/if-then/if-then.js
@@ -2,6 +2,7 @@
 // @flow
 
 import type { IfThenType } from "./if-then.js.flow"
+import { i } from "../i/i"
 
 /**
  * Functional if-then-else
@@ -10,16 +11,12 @@ import type { IfThenType } from "./if-then.js.flow"
  *
  * @param  {Function}  conditionFn  Condition function
  * @param  {Function}  thenFn       Then function
- * @param  {Function}  elseFn       Else function, if not specified will return
- *                                  input
+ * @param  {Function}  elseFn       Else function, defaults to identity
+ * @param  {mixed}     input        Input
  *
  * @return {mixed}
  */
-const ifThen: IfThenType = <A, B, C>(conditionFn, thenFn, elseFn) => input =>
-  conditionFn(input)
-    ? thenFn(input)
-    : typeof elseFn === "function"
-    ? elseFn(input)
-    : input
+const ifThen: IfThenType = <A, B>(conditionFn, thenFn, elseFn = i) => input =>
+  conditionFn(input) ? thenFn(input) : elseFn(input)
 
 export { ifThen }

--- a/src/if-then/if-then.js.flow
+++ b/src/if-then/if-then.js.flow
@@ -1,10 +1,10 @@
 // @flow
 
-type IfThenType = <A, B, C>(
+type IfThenType = <A, B>(
   conditionFn: (A) => boolean,
   thenFn: (A) => B,
-  elseFn: ?(A) => C
-) => A | B | C
+  elseFn: (A) => B
+) => B
 
 declare export var ifThen: IfThenType
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export { all } from "./all/all"
 export { any } from "./any/any"
+export { cases } from "./cases/cases"
 export { concat } from "./concat/concat"
 export { contains } from "./contains/contains"
 export { count, countBy } from "./count/count"

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -4,6 +4,7 @@ declare module "@leeruniek/functies" {
   declare module.exports: {
     all: AllType,
     any: AnyType,
+    cases: CasesType,
     filter: FilterType,
     groupBy: GroupByType,
     map: MapType,


### PR DESCRIPTION
Add the `cases` function, which is a companion to `ifThen` that approximates a switch/case statement.

Also in this PR, I restricted the type of `ifThen` so the `then` and `else` branches must return values the same type. Reasoning:

- It means the result type is consistent regardless of which branch is taken. An option type can be used as the return type parameter if multiple types are really needed, but I suspect that this restriction will not matter much in practice (`ifThen` previously returned `A | B | C` which required handling by any functions which operated on its output).

- `cases` is not possible to type properly if each case can produce a different result type. Making this change makes the two functions consistent with each other.